### PR TITLE
Fix Quick Restart for StS2 v0.107.0

### DIFF
--- a/Keybind.cs
+++ b/Keybind.cs
@@ -17,16 +17,6 @@ public class Keybind
 
     private static void Postfix(InputEvent inputEvent)
     {
-        // Skip logic if feedback screen is open
-        if (inputEvent is InputEventKey)
-        {
-            NGame? instance = NGame.Instance;
-            if (instance is { FeedbackScreen.Visible: true })
-            {
-                return;
-            }
-        }
-
         if (inputEvent is InputEventKey { Keycode: Key.R } inputKey)
         {
             switch (inputKey.Pressed)

--- a/QuickRestart.cs
+++ b/QuickRestart.cs
@@ -154,7 +154,7 @@ public class QuickRestart
         MainFile.Logger.Info("Managed to load run data");
 
         // Make use of run data to reload current run
-        RunManager.Instance.SetUpSavedSinglePlayer(runState, serializableRun);
+        RunManager.Instance.SetUpSavedSingleplayer(runState, serializableRun);
         MainFile.Logger.Info($"Continuing run with character: {serializableRun.Players[0].CharacterId}");
         SfxCmd.Play(runState.Players[0].Character.CharacterTransitionSfx);
         NGame.Instance.ReactionContainer.InitializeNetworking(new NetSingleplayerGameService());

--- a/QuickRestart.json
+++ b/QuickRestart.json
@@ -4,7 +4,7 @@
   "author": "erasels",
   "description": "Provides a button that allows for quickly save&loading a room, undoing any actions taken since entering.",
   "version": "v1.0.0",
-  "min_game_version": "0.106.1",
+  "min_game_version": "0.107.0",
   "has_pck": true,
   "has_dll": true,
   "dependencies": [],


### PR DESCRIPTION
Fixes #12.

This updates Quick Restart for the Slay the Spire 2 v0.107.0 API.

Changes:
- Updated `RunManager.SetUpSavedSinglePlayer(...)` to the renamed `SetUpSavedSingleplayer(...)`.
- Removed the `NGame.FeedbackScreen` check from the R-key handler because `NGame.get_FeedbackScreen()` no longer exists in v0.107.0.
- Bumped `min_game_version` to `0.107.0`.

Tested locally on StS2 v0.107.0:
- The Restart Room pause-menu button reloads the current room.
- Long-pressing `R` reloads the current room.